### PR TITLE
Add KoboldCPP support and Silly Tavern API endpoint

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -58,7 +58,53 @@ You need two free programs to run the app.
 * Open in Browser:
     * Open your web browser and go to the following address:
         http://127.0.0.1:5000
-* The splash screen will appear. Press Enter to begin the on-screen setup guide. Enjoy! 
+* The splash screen will appear. Press Enter to begin the on-screen setup guide. Enjoy!
+
+### Using a Different LLM Backend (KoboldCPP, etc.)
+
+StrokeGPT now supports multiple local LLM providers. By default it speaks to Ollama, but you can switch to KoboldCPP (or point it at another Ollama host) by updating `my_settings.json` after the app creates it the first time you run the server.
+
+```json
+{
+  "llm_provider": "koboldcpp",           // "ollama" or "koboldcpp"
+  "llm_base_url": "http://127.0.0.1:5001", // Base URL without the path segment
+  "llm_model": "kobold_model_name"
+}
+```
+
+* **Ollama:** keep `llm_provider` as `"ollama"`. `llm_base_url` should point at your Ollama instance (e.g., `http://127.0.0.1:11434`).
+* **KoboldCPP:** set `llm_provider` to `"koboldcpp"` and point `llm_base_url` at the KoboldCPP server root. The service uses the `/api/v1/generate` endpoint and sends conversation history with sensible defaults for temperature, top-p, repetition penalty, and stop sequences.
+
+Restart the app after changing the file so the new backend is loaded.
+
+### Silly Tavern / External Client API
+
+Third-party chat clients can talk to StrokeGPT via the new synchronous endpoint:
+
+* **Endpoint:** `POST http://127.0.0.1:5000/api/chat`
+* **Request body:**
+
+  ```json
+  {
+    "message": "Your chat text",
+    "key": "<handy api key>",
+    "persona_desc": "Optional persona override"
+  }
+  ```
+
+* **Response body:**
+
+  ```json
+  {
+    "status": "ok",
+    "chat": "Assistant reply text",
+    "move": {"sp": 50, "dp": 50, "rng": 100},
+    "new_mood": "Playful"
+  }
+  ```
+
+The endpoint mirrors the in-app `/send_message` logic: it validates your Handy key, honours STOP/auto/edging commands, and executes motion instructions immediately when no background mode is active. When a command takes over (e.g., `stop`), the JSON `status` describes the outcome instead of returning chat text.
+ 
 
 *A Quick Note on Speed
 

--- a/app.py
+++ b/app.py
@@ -17,14 +17,21 @@ from background_modes import AutoModeThread, auto_mode_logic, milking_mode_logic
 
 # ─── INITIALIZATION ───────────────────────────────────────────────────────────────────────────────────
 app = Flask(__name__)
-LLM_URL = "http://127.0.0.1:11434/api/chat"
 settings = SettingsManager(settings_file_path="my_settings.json")
 settings.load()
 
 handy = HandyController(settings.handy_key)
 handy.update_settings(settings.min_speed, settings.max_speed, settings.min_depth, settings.max_depth)
 
-llm = LLMService(url=LLM_URL)
+try:
+    llm = LLMService(
+        provider=settings.llm_provider,
+        base_url=settings.llm_base_url,
+        model=settings.llm_model,
+    )
+except ValueError as exc:
+    print(f"⚠️ {exc}. Falling back to Ollama defaults.")
+    llm = LLMService()
 audio = AudioService()
 if settings.elevenlabs_api_key:
     if audio.set_api_key(settings.elevenlabs_api_key):
@@ -96,6 +103,39 @@ def add_message_to_queue(text, add_to_history=True):
         clean_text = re.sub(r'<[^>]+>', '', text).strip()
         if clean_text: chat_history.append({"role": "assistant", "content": clean_text})
     threading.Thread(target=audio.generate_audio_for_text, args=(text,)).start()
+
+def _sync_settings_from_payload(data):
+    if not isinstance(data, dict):
+        return
+    if (persona := data.get('persona_desc')) and persona != settings.persona_desc:
+        settings.persona_desc = persona
+        settings.save()
+    if (key := data.get('key')) and key != settings.handy_key:
+        handy.set_api_key(key)
+        settings.handy_key = key
+        settings.save()
+
+def _decrement_special_persona_counter():
+    global special_persona_mode, special_persona_interactions_left
+    if special_persona_mode is None:
+        return
+    special_persona_interactions_left -= 1
+    if special_persona_interactions_left <= 0:
+        special_persona_mode = None
+        add_message_to_queue("(Personality core reverted to standard operation.)", add_to_history=False)
+
+def _apply_llm_response(llm_response, enqueue_to_queue=True):
+    global current_mood
+    if not isinstance(llm_response, dict):
+        return
+    chat_text = llm_response.get("chat")
+    if chat_text and enqueue_to_queue:
+        add_message_to_queue(chat_text)
+    if (new_mood := llm_response.get("new_mood")):
+        current_mood = new_mood
+    move = llm_response.get("move") if isinstance(llm_response.get("move"), dict) else None
+    if not auto_mode_active_task and move:
+        handy.move(move.get("sp"), move.get("dp"), move.get("rng"))
 
 def start_background_mode(mode_logic, initial_message, mode_name):
     global auto_mode_active_task, edging_start_time
@@ -177,13 +217,10 @@ def _handle_chat_commands(text):
 @app.route('/send_message', methods=['POST'])
 def handle_user_message():
     global special_persona_mode, special_persona_interactions_left
-    data = request.json
+    data = request.get_json(silent=True) or {}
     user_input = data.get('message', '').strip()
 
-    if (p := data.get('persona_desc')) and p != settings.persona_desc:
-        settings.persona_desc = p; settings.save()
-    if (k := data.get('key')) and k != settings.handy_key:
-        handy.set_api_key(k); settings.handy_key = k; settings.save()
+    _sync_settings_from_payload(data)
     
     if not handy.handy_key: return jsonify({"status": "no_key_set"})
     if not user_input: return jsonify({"status": "empty_message"})
@@ -198,18 +235,43 @@ def handle_user_message():
         return jsonify({"status": "message_relayed_to_active_mode"})
     
     llm_response = llm.get_chat_response(chat_history, get_current_context())
-    
-    if special_persona_mode is not None:
-        special_persona_interactions_left -= 1
-        if special_persona_interactions_left <= 0:
-            special_persona_mode = None
-            add_message_to_queue("(Personality core reverted to standard operation.)", add_to_history=False)
 
-    if chat_text := llm_response.get("chat"): add_message_to_queue(chat_text)
-    if new_mood := llm_response.get("new_mood"): global current_mood; current_mood = new_mood
-    if not auto_mode_active_task and (move := llm_response.get("move")):
-        handy.move(move.get("sp"), move.get("dp"), move.get("rng"))
+    _decrement_special_persona_counter()
+    _apply_llm_response(llm_response)
     return jsonify({"status": "ok"})
+
+@app.route('/api/chat', methods=['POST'])
+def api_chat_route():
+    global special_persona_mode, special_persona_interactions_left
+    data = request.get_json(silent=True) or {}
+    user_input = data.get('message', '').strip()
+
+    _sync_settings_from_payload(data)
+
+    if not handy.handy_key: return jsonify({"status": "no_key_set"})
+    if not user_input: return jsonify({"status": "empty_message"})
+
+    chat_history.append({"role": "user", "content": user_input})
+
+    handled, response = _handle_chat_commands(user_input.lower())
+    if handled:
+        return response
+
+    if auto_mode_active_task:
+        mode_message_queue.append(user_input)
+        return jsonify({"status": "message_relayed_to_active_mode"})
+
+    llm_response = llm.get_chat_response(chat_history, get_current_context())
+
+    _decrement_special_persona_counter()
+    _apply_llm_response(llm_response)
+
+    return jsonify({
+        "status": "ok",
+        "chat": llm_response.get("chat") if isinstance(llm_response, dict) else None,
+        "move": llm_response.get("move") if isinstance(llm_response, dict) else None,
+        "new_mood": llm_response.get("new_mood") if isinstance(llm_response, dict) else None,
+    })
 
 @app.route('/check_settings')
 def check_settings_route():

--- a/llm_service.py
+++ b/llm_service.py
@@ -1,34 +1,118 @@
 import json
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any
+
 import requests
 
-class LLMService:
-    def __init__(self, url, model="llama3:8b-instruct-q4_K_M"):
-        self.url = url
+
+class _BaseLLMClient(ABC):
+    def __init__(self, base_url: str, model: str):
+        self.base_url = base_url.rstrip("/")
         self.model = model
+
+    @abstractmethod
+    def generate(self, messages: List[Dict[str, str]], temperature: float) -> str:
+        """Return the raw text content produced by the provider."""
+
+
+class _OllamaClient(_BaseLLMClient):
+    def generate(self, messages: List[Dict[str, str]], temperature: float) -> str:
+        payload = {
+            "model": self.model,
+            "stream": False,
+            "format": "json",
+            "options": {
+                "temperature": temperature,
+                "top_p": 0.95,
+                "repeat_penalty": 1.2,
+                "repeat_penalty_last_n": 40,
+            },
+            "messages": messages,
+        }
+        response = requests.post(
+            f"{self.base_url}/api/chat", json=payload, timeout=60
+        )
+        response.raise_for_status()
+        data = response.json()
+        return data.get("message", {}).get("content", "")
+
+
+class _KoboldClient(_BaseLLMClient):
+    def _format_messages(self, messages: List[Dict[str, str]]) -> str:
+        conversation_lines = []
+        for message in messages:
+            role = message.get("role", "")
+            content = message.get("content", "")
+            if role == "system":
+                conversation_lines.append(content)
+            elif role == "user":
+                conversation_lines.append(f"User: {content}")
+            else:
+                conversation_lines.append(f"Assistant: {content}")
+        conversation_lines.append("Assistant:")
+        return "\n".join(conversation_lines)
+
+    def generate(self, messages: List[Dict[str, str]], temperature: float) -> str:
+        prompt = self._format_messages(messages)
+        payload = {
+            "prompt": prompt,
+            "temperature": temperature,
+            "top_p": 0.95,
+            "typical_p": 1.0,
+            "top_k": 0,
+            "max_length": 768,
+            "min_length": 1,
+            "repetition_penalty": 1.2,
+            "stop_sequence": ["User:", "Assistant:"],
+        }
+        if self.model:
+            payload["model"] = self.model
+        response = requests.post(
+            f"{self.base_url}/api/v1/generate",
+            json=payload,
+            timeout=60,
+        )
+        response.raise_for_status()
+        data = response.json()
+        if isinstance(data, dict) and "results" in data and data["results"]:
+            return "".join(result.get("text", "") for result in data["results"])
+        return data.get("text", "") if isinstance(data, dict) else ""
+
+
+class LLMService:
+    def __init__(self, provider: str = "ollama", base_url: str = "http://127.0.0.1:11434", model: str = "llama3:8b-instruct-q4_K_M"):
+        self.provider = provider.lower()
+        self.base_url = base_url
+        self.model = model
+        self.client = self._create_client()
+
+    def _create_client(self) -> _BaseLLMClient:
+        if self.provider == "ollama":
+            return _OllamaClient(self.base_url, self.model)
+        if self.provider == "koboldcpp":
+            return _KoboldClient(self.base_url, self.model)
+        raise ValueError(f"Unsupported LLM provider: {self.provider}")
+
+    def _parse_content(self, content: Any) -> Dict[str, Any]:
+        if isinstance(content, dict):
+            return content
+        if not isinstance(content, str):
+            raise ValueError("LLM response content is not a string or dict")
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            start = content.find("{")
+            end = content.rfind("}") + 1
+            if start != -1 and end != -1 and end > start:
+                return json.loads(content[start:end])
+            raise
 
     def _talk_to_llm(self, messages, temperature=0.7):
         try:
-            response = requests.post(self.url, json={
-                "model": self.model,
-                "stream": False,
-                "format": "json",
-                "options": {"temperature": temperature, "top_p": 0.95, "repeat_penalty": 1.2, "repeat_penalty_last_n": 40},
-                "messages": messages
-            }, timeout=60)
-            
-            content = response.json()["message"]["content"]
-            return json.loads(content)
-        
-        except (json.JSONDecodeError, KeyError, requests.exceptions.RequestException) as e:
+            raw_content = self.client.generate(messages, temperature)
+            return self._parse_content(raw_content)
+        except (json.JSONDecodeError, ValueError, requests.exceptions.RequestException) as e:
             print(f"Error processing LLM response: {e}")
-            try:
-                content_str = response.json()["message"]["content"]
-                start = content_str.find('{')
-                end = content_str.rfind('}') + 1
-                if start != -1 and end != -1:
-                    return json.loads(content_str[start:end])
-            except Exception:
-                 return {"chat": f"LLM Connection Error: {e}", "move": None, "new_mood": None}
             return {"chat": f"LLM Connection Error: {e}", "move": None, "new_mood": None}
 
     def _build_system_prompt(self, context):

--- a/settings_manager.py
+++ b/settings_manager.py
@@ -19,6 +19,9 @@ class SettingsManager:
         self.session_liked_patterns = []
         self.elevenlabs_api_key = ""
         self.elevenlabs_voice_id = ""
+        self.llm_provider = "ollama"
+        self.llm_base_url = "http://127.0.0.1:11434"
+        self.llm_model = "llama3:8b-instruct-q4_K_M"
         self.min_depth = 5
         self.max_depth = 100
         self.min_speed = 10
@@ -51,6 +54,9 @@ class SettingsManager:
             self.user_profile = data.get("user_profile", self._get_default_profile())
             self.elevenlabs_api_key = data.get("elevenlabs_api_key", "")
             self.elevenlabs_voice_id = data.get("elevenlabs_voice_id", "")
+            self.llm_provider = data.get("llm_provider", "ollama")
+            self.llm_base_url = data.get("llm_base_url", "http://127.0.0.1:11434")
+            self.llm_model = data.get("llm_model", "llama3:8b-instruct-q4_K_M")
             self.min_depth = data.get("min_depth", 5)
             self.max_depth = data.get("max_depth", 100)
             self.min_speed = data.get("min_speed", 10)
@@ -85,6 +91,7 @@ class SettingsManager:
                 "persona_desc": self.persona_desc,
                 "profile_picture_b64": self.profile_picture_b64,
                 "elevenlabs_api_key": self.elevenlabs_api_key, "elevenlabs_voice_id": self.elevenlabs_voice_id,
+                "llm_provider": self.llm_provider, "llm_base_url": self.llm_base_url, "llm_model": self.llm_model,
                 "patterns": self.patterns, "milking_patterns": self.milking_patterns,
                 "rules": self.rules, "user_profile": self.user_profile,
                 "min_depth": self.min_depth, "max_depth": self.max_depth,


### PR DESCRIPTION
## Summary
- add provider-specific LLM client adapters so StrokeGPT can talk to either Ollama or KoboldCPP using settings-backed configuration
- expose a synchronous `/api/chat` route that mirrors the in-app logic for Silly Tavern and other third-party clients
- document the new configuration fields and external API usage in the README

## Testing
- python -m compileall app.py llm_service.py settings_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e1fb5fe3d08332aab1fe5d1bd6aeba